### PR TITLE
修复方差精度BUG

### DIFF
--- a/src/main/java/com/chenlb/mmseg4j/Chunk.java
+++ b/src/main/java/com/chenlb/mmseg4j/Chunk.java
@@ -56,7 +56,8 @@ public class Chunk {
 		}
 		return avgLen;
 	}
-	
+
+	private double varianceScale = 10000000;
 	/** Variance of Word Lengths 就是 标准差的平方 */
 	public double getVariance() {
 		if(variance < 0) {
@@ -66,6 +67,9 @@ public class Chunk {
 					sum += Math.pow(word.getLength()-getAvgLen(), 2);
 				}
 			}
+			// 无理数可能会损失精度，通过下面方法只保留小数点后N位，过滤损失的精度
+			sum = Math.round(sum * varianceScale) / varianceScale;
+
 			variance = sum/getCount();
 		}
 		return variance;

--- a/src/test/java/com/chenlb/mmseg4j/ComplexSegTest.java
+++ b/src/test/java/com/chenlb/mmseg4j/ComplexSegTest.java
@@ -99,6 +99,13 @@ public class ComplexSegTest {
 		Assert.assertEquals("广东工业大学", words);
 	}
 
+	// 测试方差精度丢失问题
+	@Test
+	public void testEffect13() throws IOException {
+		String words = segW.segWords("今天天气很不错", "|");
+		Assert.assertEquals("今天天气|很|不错", words);
+	}
+
 	@Test
 	public void testUnitEffect() throws IOException {
 		String words = segW.segWords("2008年底发了资金吗", "|");


### PR DESCRIPTION
在您Github中MMSeg4j项目的Chunk.java中，计算方差的时候会因为精度的丢失，导致相同的方差算出不同的结果，导致方差相同的候选被过滤。
例如下面的例子，虽然它们实际方差相同，但由于精度丢失，导致下面正确的结果被过滤：
- 今天天气_很不_错 (4.666666666666666)
- 今天天气_很_不错 (4.666666666666667)

我在commit中为方差只保留了7位小数来避免该问题的出现。